### PR TITLE
fix(auth): require verified email before register

### DIFF
--- a/authentication/controllers/cognito_auth_controller.py
+++ b/authentication/controllers/cognito_auth_controller.py
@@ -94,7 +94,7 @@ class CognitoAuthController:
 
     def register(self, email: str, password: str) -> dict:
         normalized = email.strip().lower()
-        remote_status = self._cognito.get_user_status(normalized)
+        remote_status, remote_email_verified = self._cognito.get_user_registration_state(normalized)
         if remote_status is None:
             raise CognitoServiceError(
                 code='UserNotFoundException',
@@ -104,6 +104,11 @@ class CognitoAuthController:
             raise CognitoServiceError(
                 code='EmailNotConfirmedException',
                 message='El correo debe estar verificado (OTP) antes de registrar la contraseña.',
+            )
+        if remote_email_verified is False:
+            raise CognitoServiceError(
+                code='EmailNotVerifiedException',
+                message='Debes verificar tu correo antes de completar el registro.',
             )
 
         remote_sub = self._cognito.get_sub_for_username(normalized)
@@ -294,6 +299,8 @@ def map_cognito_error(exc: CognitoServiceError) -> tuple[int, dict]:
     elif exc.code in ('InvalidPasswordException', 'InvalidUserStateException'):
         status = 400
     elif exc.code in ('EmailNotConfirmedException',):
+        status = 403
+    elif exc.code in ('EmailNotVerifiedException',):
         status = 403
     elif exc.code in ('SubMismatchException', 'LocalProfileEmailMismatchException'):
         status = 409

--- a/authentication/services/cognito_service.py
+++ b/authentication/services/cognito_service.py
@@ -114,6 +114,29 @@ class CognitoService:
     def get_user_status(self, email: str) -> str | None:
         return self._user_status_optional(email)
 
+    @staticmethod
+    def _parse_bool_attr(value: str | None) -> bool | None:
+        if value is None:
+            return None
+        normalized = str(value).strip().lower()
+        if normalized in ('true', '1', 'yes'):
+            return True
+        if normalized in ('false', '0', 'no'):
+            return False
+        return None
+
+    def get_user_registration_state(self, email: str) -> tuple[str | None, bool | None]:
+        r = self._admin_get_user_optional(email)
+        if not r:
+            return None, None
+        user_status = r.get('UserStatus')
+        email_verified: bool | None = None
+        for attr in r.get('UserAttributes') or []:
+            if attr.get('Name') == 'email_verified':
+                email_verified = self._parse_bool_attr(attr.get('Value'))
+                break
+        return user_status, email_verified
+
     def get_sub_for_username(self, email: str) -> str | None:
         r = self._admin_get_user_optional(email)
         return self._sub_from_admin_user(r) if r else None

--- a/authentication/tests/test_auth_controller_flow.py
+++ b/authentication/tests/test_auth_controller_flow.py
@@ -71,17 +71,27 @@ class AuthRegisterTests(TestCase):
 
     def test_register_rechaza_si_no_confirmado(self):
         cognito = MagicMock()
-        cognito.get_user_status.return_value = 'UNCONFIRMED'
+        cognito.get_user_registration_state.return_value = ('UNCONFIRMED', False)
         cognito.get_sub_for_username.return_value = 'sub-x'
         with self.assertRaises(CognitoServiceError) as ctx:
             CognitoAuthController(cognito=cognito).register(self.email, 'Password1!a')
 
         self.assertEqual(ctx.exception.code, 'EmailNotConfirmedException')
         self.assertEqual(Usuario.objects.count(), 0)
+        cognito.admin_set_user_password_permanent.assert_not_called()
+
+    def test_register_rechaza_si_email_verified_false(self):
+        cognito = MagicMock()
+        cognito.get_user_registration_state.return_value = ('CONFIRMED', False)
+        with self.assertRaises(CognitoServiceError) as ctx:
+            CognitoAuthController(cognito=cognito).register(self.email, 'Password1!a')
+        self.assertEqual(ctx.exception.code, 'EmailNotVerifiedException')
+        self.assertEqual(Usuario.objects.count(), 0)
+        cognito.admin_set_user_password_permanent.assert_not_called()
 
     def test_register_crea_usuario_minimo(self):
         cognito = MagicMock()
-        cognito.get_user_status.return_value = 'CONFIRMED'
+        cognito.get_user_registration_state.return_value = ('CONFIRMED', True)
         cognito.get_sub_for_username.return_value = 'stable-sub-123'
 
         out = CognitoAuthController(cognito=cognito).register(self.email, 'Password1!a')
@@ -101,7 +111,7 @@ class AuthRegisterTests(TestCase):
             rol=RolUsuario.USER,
         )
         cognito = MagicMock()
-        cognito.get_user_status.return_value = 'CONFIRMED'
+        cognito.get_user_registration_state.return_value = ('CONFIRMED', True)
         cognito.get_sub_for_username.return_value = 'stable-sub-123'
 
         out = CognitoAuthController(cognito=cognito).register(self.email, 'Password1!a')
@@ -113,7 +123,7 @@ class AuthRegisterTests(TestCase):
     def test_register_completa_sub_si_usuario_legacy_sin_sub(self):
         Usuario.objects.create(correo=self.email, sub_cognito=None, rol=RolUsuario.USER)
         cognito = MagicMock()
-        cognito.get_user_status.return_value = 'CONFIRMED'
+        cognito.get_user_registration_state.return_value = ('CONFIRMED', True)
         cognito.get_sub_for_username.return_value = 'filled-sub'
 
         out = CognitoAuthController(cognito=cognito).register(self.email, 'Password1!a')
@@ -130,7 +140,7 @@ class AuthRegisterTests(TestCase):
             rol=RolUsuario.USER,
         )
         cognito = MagicMock()
-        cognito.get_user_status.return_value = 'CONFIRMED'
+        cognito.get_user_registration_state.return_value = ('CONFIRMED', True)
         cognito.get_sub_for_username.return_value = 'cognito-sub-distinto'
 
         with self.assertRaises(CognitoServiceError) as ctx:

--- a/authentication/tests/test_auth_views.py
+++ b/authentication/tests/test_auth_views.py
@@ -29,6 +29,14 @@ class AuthRegisterViewTests(TestCase):
         r2 = self.client.post('/auth/register/', {'email': 'a@b.com', 'password': 'Password1!x'}, format='json')
         self.assertEqual(r2.status_code, status.HTTP_200_OK)
 
+    def test_swagger_register_indica_dependencia_de_validate(self):
+        r = self.client.get('/swagger.json')
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        post = r.json()['paths']['/auth/register/']['post']
+        desc = (post.get('description') or '').lower()
+        self.assertIn('verificar', desc)
+        self.assertIn('confirmed', desc)
+
 
 class AuthSendViewUsuarioTests(TestCase):
     def setUp(self):

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -197,7 +197,8 @@ _AUTH_REGISTER_DESCRIPTION = (
     '**Fase B — registro de cuenta.** Tras verificar el correo, fija la contraseña definitiva en Cognito '
     'y crea el `Usuario` mínimo local.\n\n'
     '- **Cuerpo:** `email` y `password` (JSON).\n'
-    '- **Requisito:** el correo debe estar `CONFIRMED` en Cognito.\n'
+    '- **Requisito estricto (Cognito como fuente de verdad):** el usuario debe estar `CONFIRMED` '
+    'y con `email_verified=true` (cuando el atributo está disponible).\n'
     '- **No devuelve tokens:** para obtener JWT usa `POST /auth/login/` después del registro.\n'
 )
 
@@ -341,7 +342,7 @@ class AuthRegisterView(APIView):
             ),
             400: openapi.Response(description='Contraseña inválida u error Cognito.', schema=_COGNITO_ERROR),
             403: openapi.Response(
-                description='Correo aún no verificado (OTP pendiente).',
+                description='Correo aún no verificado en Cognito (`CONFIRMED`/`email_verified`).',
                 schema=_COGNITO_ERROR,
             ),
             404: openapi.Response(description='Sin usuario en Cognito.', schema=_COGNITO_ERROR),


### PR DESCRIPTION
---
name: 🔄 Pull Request
about: Template para Pull Requests en CodeMio Backend
title: '[FEAT] Implementa flujo de autenticación con Cognito: verificación, registro, login, logout y onboarding'
labels: ''
assignees: @M4ltin12 ''
---

## 📋 Información del Pull Request

### 🏷️ Versión y Ambiente

- **Versión:** v0.0.0
- **Ambiente afectado:** 
  - [x] Desarrollo
  - [ ] Producción
- **Rama base:** `develop`
- **Rama feature:** `BE-AUTH-01-05`

---

### 📝 Descripción

**¿Qué hace este PR?**

Implementa y consolida el flujo completo de autenticación basado en AWS Cognito para `codemio_back`, separando claramente las fases de:

- verificación de correo (`send` / `validate`)
- registro (`register`)
- login (`login`)
- logout (`logout`)
- onboarding/perfil (`users/me`)

También reorganiza la semántica del módulo para que:

- `CognitoUser` represente la trazabilidad del flujo con Cognito
- `Usuario` represente el perfil local de negocio
- el backend use únicamente `access_token` para endpoints protegidos
- el flujo quede documentado y endurecido para producción

---

**¿Por qué es necesario este cambio?**

Porque el flujo anterior estaba incompleto y mezclaba responsabilidades:

- el usuario local podía crearse demasiado pronto durante la validación OTP
- no existía una fase explícita de registro real
- no existía login ni logout
- había ambigüedad entre `id_token` y `access_token`
- el onboarding no estaba claramente separado del registro
- algunas respuestas exponían información innecesaria para producción

Este cambio deja un flujo coherente, seguro y alineado con la arquitectura actual del proyecto.

---

**¿Qué problema resuelve?**

Resuelve los siguientes problemas:

- separación incorrecta entre verificación, registro y perfil
- ausencia de login y logout
- falta de consistencia entre Cognito y `Usuario`
- uso ambiguo de tokens para endpoints protegidos
- creación incorrecta de `Usuario` en `validate`
- exposición de payloads técnicos de Cognito en respuestas de API
- falta de documentación actualizada del journey completo

---

### 🔄 Pasos para Reproducir / Probar

1. Ejecutar migraciones:
   ```bash
   python manage.py migrate