### PR TITLE
feat(auth): add forgot password flow with cognito otp probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ El proyecto consiste en el desarrollo de una aplicación web que permita a los u
 
 ### Características Principales
 
-✅ **Registro y autenticación de usuarios** con **Amazon Cognito** (OTP por correo, registro, login JWT, renovación con refresh token, logout) y perfil local (`Usuario`); ver [authentication/README.md](authentication/README.md)  
+✅ **Registro y autenticación de usuarios** con **Amazon Cognito** (OTP por correo, registro, login JWT, renovación con refresh token, logout, **recuperación de contraseña en tres pasos** con sondeo de OTP) y perfil local (`Usuario`); ver [authentication/README.md](authentication/README.md)  
 ✅ **Gestión completa de proyectos Java** (crear, editar, eliminar, listar)  
 ✅ **Carga de archivos** individuales o en lote (`.java` y `.zip`)  
 ✅ **Descompresión automática** de archivos comprimidos  
@@ -66,7 +66,7 @@ Este proyecto incluye documentación detallada para facilitar el desarrollo:
 | Archivo | Propósito |
 |---------|-----------|
 | [`README.md`](README.md) | **Guía principal** - Instalación, configuración y uso general |
-| [`authentication/README.md`](authentication/README.md) | **Autenticación** - Flujo Cognito (send → validate → register → login → refresh → users/me → logout), tokens y modelos |
+| [`authentication/README.md`](authentication/README.md) | **Autenticación** - Flujo Cognito (send → validate → register → login → refresh → users/me → logout), **forgot-password → validate-code → confirm-forgot-password**, tokens y modelos |
 | [`CONFIGURATION_SUMMARY.md`](CONFIGURATION_SUMMARY.md) | **Resumen de configuración** - Explicación detallada de todos los archivos de configuración |
 | [`COMMANDS.md`](COMMANDS.md) | **Referencia de comandos** - Lista completa de comandos útiles para desarrollo |
 | [`PROJECT_MAP.md`](PROJECT_MAP.md) | **Mapa técnico del proyecto** - Arquitectura y flujos visualizados con Mermaid |

--- a/authentication/controllers/cognito_auth_controller.py
+++ b/authentication/controllers/cognito_auth_controller.py
@@ -1,4 +1,8 @@
 from django.conf import settings
+from authentication.forgot_password_otp_probe import (
+    FORGOT_PASSWORD_OTP_PROBE_PASSWORD,
+    assert_forgot_password_otp_probe_configured,
+)
 from authentication.models import CognitoUser, CognitoUserStatus, Usuario
 from authentication.serializers import UsuarioMeReadSerializer
 from authentication.services.cognito_service import (
@@ -15,6 +19,84 @@ class CognitoAuthController:
     def __init__(self, cognito: CognitoService | None = None):
         from authentication.services import get_cognito_service
         self._cognito = cognito or get_cognito_service()
+
+    @staticmethod
+    def _ensure_usuario_exists_for_forgot(normalized_email: str) -> None:
+        if not Usuario.objects.filter(correo=normalized_email).exists():
+            raise CognitoServiceError(
+                code='UserNotFoundException',
+                message='Invalid credentials.',
+            )
+
+    def forgot_password(self, email: str) -> dict:
+        normalized = email.strip().lower()
+        self._ensure_usuario_exists_for_forgot(normalized)
+        self._cognito.forgot_password(normalized)
+        return {
+            'detail': 'Revisa tu correo para el código de recuperación de contraseña.',
+            'email': normalized,
+        }
+
+    def validate_forgot_password_code(self, email: str, code: str) -> dict:
+        normalized = email.strip().lower()
+        code_stripped = (code or '').strip()
+        self._ensure_usuario_exists_for_forgot(normalized)
+        assert_forgot_password_otp_probe_configured()
+        try:
+            self._cognito.confirm_forgot_password_otp_probe(
+                normalized, code_stripped, FORGOT_PASSWORD_OTP_PROBE_PASSWORD
+            )
+        except CognitoServiceError as e:
+            if e.code == 'InvalidPasswordException':
+                return {
+                    'valid': True,
+                    'detail': 'Código de recuperación válido. Continúa con POST /auth/confirm-forgot-password/.',
+                }
+            if e.code == 'CodeMismatchException':
+                raise CognitoServiceError(
+                    code='CodeMismatchException',
+                    message='Código de verificación incorrecto.',
+                ) from e
+            if e.code == 'ExpiredCodeException':
+                raise CognitoServiceError(
+                    code='ExpiredCodeException',
+                    message='El código de verificación ha expirado.',
+                ) from e
+            if e.code == 'InvalidParameterException':
+                raise CognitoServiceError(
+                    code='CodeMismatchException',
+                    message='Código de verificación incorrecto o no válido.',
+                ) from e
+            if e.code == 'UserNotFoundException':
+                raise CognitoServiceError(
+                    code='UserNotFoundException',
+                    message='Invalid credentials.',
+                ) from e
+            if e.code in ('TooManyRequestsException', 'LimitExceededException'):
+                raise CognitoServiceError(
+                    code=e.code,
+                    message='Demasiados intentos. Inténtalo de nuevo más tarde.',
+                ) from e
+            raise CognitoServiceError(
+                code='ForgotPasswordOtpProbeUnexpected',
+                message='No se pudo validar el código de recuperación.',
+            ) from e
+        raise CognitoServiceError(
+            code='ForgotPasswordOtpProbeUnexpected',
+            message=(
+                'Respuesta inesperada del proveedor al validar el código. '
+                'Contacta con soporte si el problema continúa.'
+            ),
+        )
+
+    def confirm_forgot_password(self, email: str, code: str, new_password: str) -> dict:
+        normalized = email.strip().lower()
+        self._ensure_usuario_exists_for_forgot(normalized)
+        self._cognito.confirm_forgot_password(normalized, (code or '').strip(), new_password)
+        return {
+            'detail': 'Contraseña actualizada correctamente.',
+            'email': normalized,
+        }
 
     def _sync_cognito_sub_from_remote(self, normalized: str) -> str | None:
         remote = self._cognito.get_sub_for_username(normalized)
@@ -296,6 +378,10 @@ def map_cognito_error(exc: CognitoServiceError) -> tuple[int, dict]:
         status = 429
     elif exc.code in ('NotAuthorizedException',):
         status = 401
+    elif exc.code in ('ForgotPasswordOtpProbeUnexpected',):
+        status = 500
+    elif exc.code in ('ExpiredCodeException', 'CodeMismatchException'):
+        status = 400
     elif exc.code in ('InvalidPasswordException', 'InvalidUserStateException'):
         status = 400
     elif exc.code in ('EmailNotConfirmedException',):

--- a/authentication/forgot_password_otp_probe.py
+++ b/authentication/forgot_password_otp_probe.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import re
+from django.core.exceptions import ImproperlyConfigured
+
+FORGOT_PASSWORD_OTP_PROBE_PASSWORD = 'Abcdefgh!'
+_MIN_COGNITO_PASSWORD_FIELD_LENGTH = 8
+
+
+def _password_would_satisfy_full_user_policy(password: str) -> bool:
+    if len(password) < _MIN_COGNITO_PASSWORD_FIELD_LENGTH:
+        return False
+    if not re.search(r'[A-Z]', password):
+        return False
+    if not re.search(r'[a-z]', password):
+        return False
+    if not re.search(r'\d', password):
+        return False
+    if not re.search(r'[^A-Za-z0-9]', password):
+        return False
+    return True
+
+def assert_forgot_password_otp_probe_configured(probe_password: str | None = None) -> None:
+    probe = probe_password if probe_password is not None else FORGOT_PASSWORD_OTP_PROBE_PASSWORD
+    if not isinstance(probe, str) or not probe.strip():
+        raise ImproperlyConfigured(
+            'FORGOT_PASSWORD_OTP_PROBE_PASSWORD must be a non-empty string for Cognito API validation.'
+        )
+    if len(probe) < _MIN_COGNITO_PASSWORD_FIELD_LENGTH:
+        raise ImproperlyConfigured(
+            f'FORGOT_PASSWORD_OTP_PROBE_PASSWORD must be at least '
+            f'{_MIN_COGNITO_PASSWORD_FIELD_LENGTH} characters so Cognito evaluates password policy '
+            'rather than rejecting basic shape.'
+        )
+    if _password_would_satisfy_full_user_policy(probe):
+        raise ImproperlyConfigured(
+            'FORGOT_PASSWORD_OTP_PROBE_PASSWORD must not satisfy the full password policy check; '
+            'otherwise Cognito could accept the probe as a real password and complete the reset.'
+        )

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -19,6 +19,23 @@ class AuthLoginSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField(write_only=True, min_length=1, max_length=128)
 
+class AuthForgotPasswordSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+
+class AuthForgotPasswordValidateSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    code = serializers.CharField(
+        max_length=32,
+        help_text='Código recibido por correo tras POST /auth/forgot-password/.',
+    )
+
+
+class AuthConfirmForgotPasswordSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    code = serializers.CharField(max_length=32)
+    new_password = serializers.CharField(write_only=True, min_length=8, max_length=128)
+
 
 class AuthRefreshSerializer(serializers.Serializer):
     refresh_token = serializers.CharField(

--- a/authentication/services/cognito_service.py
+++ b/authentication/services/cognito_service.py
@@ -364,6 +364,55 @@ class CognitoService:
             self._log_client_error('GlobalSignOut', log_label, e)
             raise self._map_client_error(e) from e
 
+    def forgot_password(self, email: str) -> dict[str, Any]:
+        try:
+            params = {
+                'ClientId': self.client_id,
+                'Username': email,
+                **self._secret_hash_payload(email),
+            }
+            response = self.client.forgot_password(**params)
+            self._log_success('ForgotPassword', email, response)
+            return response
+        except ClientError as e:
+            self._log_client_error('ForgotPassword', email, e)
+            raise self._map_client_error(e) from e
+
+    def confirm_forgot_password(self, email: str, code: str, new_password: str) -> dict[str, Any]:
+        try:
+            params = {
+                'ClientId': self.client_id,
+                'Username': email,
+                'ConfirmationCode': code,
+                'Password': new_password,
+                **self._secret_hash_payload(email),
+            }
+            response = self.client.confirm_forgot_password(**params)
+            self._log_success('ConfirmForgotPassword', email, response)
+            return response
+        except ClientError as e:
+            self._log_client_error('ConfirmForgotPassword', email, e)
+            raise self._map_client_error(e) from e
+
+    def confirm_forgot_password_otp_probe(
+        self, email: str, code: str, probe_password: str
+    ) -> dict[str, Any]:
+
+        try:
+            params = {
+                'ClientId': self.client_id,
+                'Username': email,
+                'ConfirmationCode': code,
+                'Password': probe_password,
+                **self._secret_hash_payload(email),
+            }
+            response = self.client.confirm_forgot_password(**params)
+            self._log_success('ConfirmForgotPasswordOtpProbe', email, response)
+            return response
+        except ClientError as e:
+            self._log_client_error('ConfirmForgotPasswordOtpProbe', email, e)
+            raise self._map_client_error(e) from e
+
     @staticmethod
     def _map_client_error(e: ClientError) -> CognitoServiceError:
         err = e.response.get('Error', {})

--- a/authentication/tests/test_cognito_service_forgot_password.py
+++ b/authentication/tests/test_cognito_service_forgot_password.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+from botocore.exceptions import ClientError
+from django.test import SimpleTestCase
+from authentication.services.cognito_service import CognitoService, CognitoServiceError
+
+class CognitoForgotPasswordServiceTests(SimpleTestCase):
+    @patch('authentication.services.cognito_service.boto3.client')
+    def test_forgot_password_calls_client(self, mock_boto_client):
+        mock_boto = MagicMock()
+        mock_boto_client.return_value = mock_boto
+        mock_boto.forgot_password.return_value = {'ResponseMetadata': {'RequestId': 'r'}}
+        svc = CognitoService(
+            client_id='cid',
+            client_secret='',
+            region='us-east-1',
+            user_pool_id='pool',
+        )
+        svc.forgot_password('u@e.com')
+        mock_boto.forgot_password.assert_called_once_with(
+            ClientId='cid',
+            Username='u@e.com',
+        )
+
+    @patch('authentication.services.cognito_service.boto3.client')
+    def test_confirm_forgot_password_maps_client_error(self, mock_boto_client):
+        mock_boto = MagicMock()
+        mock_boto_client.return_value = mock_boto
+        mock_boto.confirm_forgot_password.side_effect = ClientError(
+            {
+                'Error': {'Code': 'CodeMismatchException', 'Message': 'bad'},
+                'ResponseMetadata': {},
+            },
+            'ConfirmForgotPassword',
+        )
+        svc = CognitoService(
+            client_id='cid',
+            client_secret='',
+            region='us-east-1',
+            user_pool_id='pool',
+        )
+        with self.assertRaises(CognitoServiceError) as ctx:
+            svc.confirm_forgot_password('u@e.com', '123456', 'Newpass1!x')
+        self.assertEqual(ctx.exception.code, 'CodeMismatchException')
+
+    @patch('authentication.services.cognito_service.boto3.client')
+    def test_confirm_forgot_password_otp_probe_propagates_invalid_password_code(self, mock_boto_client):
+        mock_boto = MagicMock()
+        mock_boto_client.return_value = mock_boto
+        mock_boto.confirm_forgot_password.side_effect = ClientError(
+            {
+                'Error': {'Code': 'InvalidPasswordException', 'Message': 'policy'},
+                'ResponseMetadata': {},
+            },
+            'ConfirmForgotPassword',
+        )
+        svc = CognitoService(
+            client_id='cid',
+            client_secret='',
+            region='us-east-1',
+            user_pool_id='pool',
+        )
+        with self.assertRaises(CognitoServiceError) as ctx:
+            svc.confirm_forgot_password_otp_probe('u@e.com', '123456', 'Abcdefgh!')
+        self.assertEqual(ctx.exception.code, 'InvalidPasswordException')

--- a/authentication/tests/test_forgot_password_flow.py
+++ b/authentication/tests/test_forgot_password_flow.py
@@ -1,0 +1,197 @@
+from unittest.mock import MagicMock, patch
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+from authentication.controllers.cognito_auth_controller import CognitoAuthController
+from authentication.models import Usuario
+from authentication.services.cognito_service import CognitoServiceError
+
+class CognitoAuthControllerForgotPasswordTests(TestCase):
+    def setUp(self):
+        self.email = 'user@example.com'
+        Usuario.objects.create(
+            correo=self.email,
+            sub_cognito='sub-forgot-test',
+            rol='user',
+        )
+
+    def test_forgot_password_requires_local_usuario(self):
+        cognito = MagicMock()
+        ctrl = CognitoAuthController(cognito=cognito)
+        with self.assertRaises(CognitoServiceError) as ctx:
+            ctrl.forgot_password('other@example.com')
+        self.assertEqual(ctx.exception.code, 'UserNotFoundException')
+        cognito.forgot_password.assert_not_called()
+
+    def test_forgot_password_calls_cognito(self):
+        cognito = MagicMock()
+        ctrl = CognitoAuthController(cognito=cognito)
+        out = ctrl.forgot_password(self.email)
+        cognito.forgot_password.assert_called_once_with(self.email)
+        self.assertIn('detail', out)
+        self.assertEqual(out['email'], self.email)
+
+    def test_validate_probe_invalid_password_means_success(self):
+        cognito = MagicMock()
+        cognito.confirm_forgot_password_otp_probe.side_effect = CognitoServiceError(
+            code='InvalidPasswordException',
+            message='Password does not conform to policy',
+        )
+        ctrl = CognitoAuthController(cognito=cognito)
+        out = ctrl.validate_forgot_password_code(self.email, '123456')
+        self.assertTrue(out['valid'])
+        cognito.confirm_forgot_password_otp_probe.assert_called_once()
+        args = cognito.confirm_forgot_password_otp_probe.call_args[0]
+        self.assertEqual(args[0], self.email)
+        self.assertEqual(args[1], '123456')
+
+    def test_validate_probe_code_mismatch(self):
+        cognito = MagicMock()
+        cognito.confirm_forgot_password_otp_probe.side_effect = CognitoServiceError(
+            code='CodeMismatchException',
+            message='bad',
+        )
+        ctrl = CognitoAuthController(cognito=cognito)
+        with self.assertRaises(CognitoServiceError) as ctx:
+            ctrl.validate_forgot_password_code(self.email, '000000')
+        self.assertEqual(ctx.exception.code, 'CodeMismatchException')
+
+    def test_validate_probe_expired(self):
+        cognito = MagicMock()
+        cognito.confirm_forgot_password_otp_probe.side_effect = CognitoServiceError(
+            code='ExpiredCodeException',
+            message='expired',
+        )
+        ctrl = CognitoAuthController(cognito=cognito)
+        with self.assertRaises(CognitoServiceError) as ctx:
+            ctrl.validate_forgot_password_code(self.email, '123456')
+        self.assertEqual(ctx.exception.code, 'ExpiredCodeException')
+
+    def test_validate_probe_unexpected_success_raises(self):
+        cognito = MagicMock()
+        cognito.confirm_forgot_password_otp_probe.return_value = {'ResponseMetadata': {}}
+        ctrl = CognitoAuthController(cognito=cognito)
+        with self.assertRaises(CognitoServiceError) as ctx:
+            ctrl.validate_forgot_password_code(self.email, '123456')
+        self.assertEqual(ctx.exception.code, 'ForgotPasswordOtpProbeUnexpected')
+
+    def test_confirm_forgot_password_calls_cognito(self):
+        cognito = MagicMock()
+        ctrl = CognitoAuthController(cognito=cognito)
+        out = ctrl.confirm_forgot_password(self.email, '123456', 'Newpass1!x')
+        cognito.confirm_forgot_password.assert_called_once_with(
+            self.email, '123456', 'Newpass1!x'
+        )
+        self.assertEqual(out['email'], self.email)
+
+    def test_confirm_forgot_password_propagates_invalid_code(self):
+        cognito = MagicMock()
+        cognito.confirm_forgot_password.side_effect = CognitoServiceError(
+            code='CodeMismatchException',
+            message='bad',
+        )
+        ctrl = CognitoAuthController(cognito=cognito)
+        with self.assertRaises(CognitoServiceError) as ctx:
+            ctrl.confirm_forgot_password(self.email, 'wrong', 'Newpass1!x')
+        self.assertEqual(ctx.exception.code, 'CodeMismatchException')
+
+
+class ForgotPasswordApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.email = 'api@example.com'
+        Usuario.objects.create(
+            correo=self.email,
+            sub_cognito='sub-api-forgot',
+            rol='user',
+        )
+
+    @patch('authentication.views.CognitoAuthController')
+    def test_forgot_password_endpoint_calls_controller_and_no_new_usuario(self, ctrl_cls):
+        initial_count = Usuario.objects.count()
+        ctrl = ctrl_cls.return_value
+        ctrl.forgot_password.return_value = {'detail': 'ok', 'email': self.email}
+        r = self.client.post('/auth/forgot-password/', {'email': self.email}, format='json')
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        ctrl.forgot_password.assert_called_once_with(self.email)
+        self.assertEqual(Usuario.objects.count(), initial_count)
+
+    @patch('authentication.views.CognitoAuthController')
+    def test_validate_code_success_response_has_valid_true(self, ctrl_cls):
+        ctrl = ctrl_cls.return_value
+        ctrl.validate_forgot_password_code.return_value = {
+            'valid': True,
+            'detail': 'ok',
+        }
+        r = self.client.post(
+            '/auth/forgot-password/validate-code/',
+            {'email': self.email, 'code': '123456'},
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertTrue(r.json()['valid'])
+        ctrl.validate_forgot_password_code.assert_called_once_with(self.email, '123456')
+
+    @patch('authentication.views.CognitoAuthController')
+    def test_validate_code_no_usuario_extra(self, ctrl_cls):
+        ctrl = ctrl_cls.return_value
+        ctrl.validate_forgot_password_code.return_value = {'valid': True, 'detail': 'x'}
+        n = Usuario.objects.count()
+        self.client.post(
+            '/auth/forgot-password/validate-code/',
+            {'email': self.email, 'code': '1'},
+            format='json',
+        )
+        self.assertEqual(Usuario.objects.count(), n)
+
+    @patch('authentication.views.CognitoAuthController')
+    def test_confirm_forgot_password_success(self, ctrl_cls):
+        ctrl = ctrl_cls.return_value
+        ctrl.confirm_forgot_password.return_value = {'detail': 'done', 'email': self.email}
+        r = self.client.post(
+            '/auth/confirm-forgot-password/',
+            {'email': self.email, 'code': '123456', 'new_password': 'Newpass1!x'},
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        ctrl.confirm_forgot_password.assert_called_once_with(
+            self.email, '123456', 'Newpass1!x'
+        )
+
+    @patch('authentication.views.CognitoAuthController')
+    def test_confirm_forgot_password_error_mapping(self, ctrl_cls):
+        ctrl = ctrl_cls.return_value
+        ctrl.confirm_forgot_password.side_effect = CognitoServiceError(
+            code='CodeMismatchException',
+            message='bad',
+        )
+        r = self.client.post(
+            '/auth/confirm-forgot-password/',
+            {'email': self.email, 'code': 'x', 'new_password': 'Newpass1!x'},
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        body = r.json()
+        self.assertEqual(body['code'], 'CodeMismatchException')
+        self.assertNotIn('Password', body.get('detail', ''))
+
+    @patch('authentication.views.CognitoAuthController')
+    def test_validate_unexpected_probe_maps_500(self, ctrl_cls):
+        ctrl = ctrl_cls.return_value
+        ctrl.validate_forgot_password_code.side_effect = CognitoServiceError(
+            code='ForgotPasswordOtpProbeUnexpected',
+            message='unexpected',
+        )
+        r = self.client.post(
+            '/auth/forgot-password/validate-code/',
+            {'email': self.email, 'code': '1'},
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def test_swagger_mentions_forgot_flow_order(self):
+        r = self.client.get('/swagger.json')
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        info = r.json().get('info', {}).get('description', '').lower()
+        self.assertIn('forgot-password', info)
+        self.assertIn('validate-code', info)

--- a/authentication/tests/test_forgot_password_otp_probe.py
+++ b/authentication/tests/test_forgot_password_otp_probe.py
@@ -1,0 +1,25 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+from authentication.forgot_password_otp_probe import (
+    FORGOT_PASSWORD_OTP_PROBE_PASSWORD,
+    assert_forgot_password_otp_probe_configured,
+)
+
+class ForgotPasswordOtpProbeAssertTests(SimpleTestCase):
+    def test_default_probe_passes_assert(self):
+        assert_forgot_password_otp_probe_configured()
+
+    def test_default_probe_matches_aiteva_constant(self):
+        self.assertEqual(FORGOT_PASSWORD_OTP_PROBE_PASSWORD, 'Abcdefgh!')
+
+    def test_probe_too_short_raises(self):
+        with self.assertRaises(ImproperlyConfigured):
+            assert_forgot_password_otp_probe_configured('Ab1!x')
+
+    def test_probe_that_satisfies_full_policy_raises(self):
+        with self.assertRaises(ImproperlyConfigured):
+            assert_forgot_password_otp_probe_configured('Abcd1234!')
+
+    def test_empty_probe_raises(self):
+        with self.assertRaises(ImproperlyConfigured):
+            assert_forgot_password_otp_probe_configured('')

--- a/authentication/tests/test_forgot_password_otp_probe.py
+++ b/authentication/tests/test_forgot_password_otp_probe.py
@@ -9,7 +9,7 @@ class ForgotPasswordOtpProbeAssertTests(SimpleTestCase):
     def test_default_probe_passes_assert(self):
         assert_forgot_password_otp_probe_configured()
 
-    def test_default_probe_matches_aiteva_constant(self):
+    def test_default_probe_matches(self):
         self.assertEqual(FORGOT_PASSWORD_OTP_PROBE_PASSWORD, 'Abcdefgh!')
 
     def test_probe_too_short_raises(self):

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -246,8 +246,6 @@ _AUTH_FORGOT_PASSWORD_DESCRIPTION = (
     '**Recuperación de contraseña — paso 1.** Envía el código por correo vía Cognito `ForgotPassword`.\n\n'
     '- **Orden:** `POST /auth/forgot-password/` → `POST /auth/forgot-password/validate-code/` → '
     '`POST /auth/confirm-forgot-password/`.\n'
-    '- **Requisito:** debe existir un `Usuario` local con ese correo (paridad con Aiteva).\n'
-    '- **No** crea ni modifica `Usuario`; independiente de registro/login.\n'
 )
 
 _AUTH_FORGOT_VALIDATE_DESCRIPTION = (
@@ -295,9 +293,9 @@ class AuthForgotPasswordView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['03 Recuperación de contraseña'],
         operation_id='auth_forgot_password',
-        operation_summary='Recuperación: enviar código al correo',
+        operation_summary='(1/3) Recuperación: solicitar código al correo',
         operation_description=_AUTH_FORGOT_PASSWORD_DESCRIPTION,
         security=[],
         request_body=AuthForgotPasswordSerializer,
@@ -330,9 +328,9 @@ class AuthForgotPasswordValidateCodeView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['03 Recuperación de contraseña'],
         operation_id='auth_forgot_password_validate_code',
-        operation_summary='Recuperación: validar OTP (sondeo Cognito)',
+        operation_summary='(2/3) Recuperación: validar OTP (sondeo Cognito)',
         operation_description=_AUTH_FORGOT_VALIDATE_DESCRIPTION,
         security=[],
         request_body=AuthForgotPasswordValidateSerializer,
@@ -372,9 +370,9 @@ class AuthConfirmForgotPasswordView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['03 Recuperación de contraseña'],
         operation_id='auth_confirm_forgot_password',
-        operation_summary='Recuperación: nueva contraseña definitiva',
+        operation_summary='(3/3) Recuperación: nueva contraseña definitiva',
         operation_description=_AUTH_CONFIRM_FORGOT_DESCRIPTION,
         security=[],
         request_body=AuthConfirmForgotPasswordSerializer,
@@ -411,7 +409,7 @@ class AuthSendView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['02 Verificación de correo'],
         operation_id='auth_send',
         operation_summary='Fase A: enviar OTP de verificación de correo',
         operation_description=_AUTH_SEND_DESCRIPTION,
@@ -449,7 +447,7 @@ class AuthValidateView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['02 Verificación de correo'],
         operation_id='auth_validate',
         operation_summary='Fase A: validar OTP y confirmar correo',
         operation_description=_AUTH_VALIDATE_DESCRIPTION,
@@ -491,9 +489,9 @@ class AuthRegisterView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['04 Registro y login'],
         operation_id='auth_register',
-        operation_summary='Fase B: contraseña definitiva y usuario local mínimo',
+        operation_summary='(1/2) Fase B: registro — contraseña definitiva y usuario local mínimo',
         operation_description=_AUTH_REGISTER_DESCRIPTION,
         security=[],
         request_body=AuthRegisterSerializer,
@@ -535,9 +533,9 @@ class AuthLoginView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['01 Sesión', '04 Registro y login'],
         operation_id='auth_login',
-        operation_summary='Fase C: login (email + contraseña)',
+        operation_summary='(2/2) Fase C: login (email + contraseña)',
         operation_description=_AUTH_LOGIN_DESCRIPTION,
         security=[],
         request_body=AuthLoginSerializer,
@@ -580,7 +578,7 @@ class AuthRefreshView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['01 Sesión'],
         operation_id='auth_refresh',
         operation_summary='Renovar tokens (refresh_token, sin Bearer)',
         operation_description=_AUTH_REFRESH_DESCRIPTION,
@@ -622,7 +620,7 @@ class AuthLogoutView(APIView):
     permission_classes = [IsAuthenticated]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['01 Sesión'],
         operation_id='auth_logout',
         operation_summary='Cerrar sesión en Cognito (access token actual)',
         operation_description=_AUTH_LOGOUT_DESCRIPTION,
@@ -661,7 +659,7 @@ class UsersMeView(APIView):
     permission_classes = [IsAuthenticated]
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['05 Perfil y onboarding'],
         operation_id='users_me_get',
         operation_summary='Fase D: leer perfil local',
         operation_description=_USERS_ME_DESCRIPTION,
@@ -676,7 +674,7 @@ class UsersMeView(APIView):
         return Response(UsuarioMeReadSerializer(usuario).data)
 
     @swagger_auto_schema(
-        tags=['Autenticación'],
+        tags=['05 Perfil y onboarding'],
         operation_id='users_me_patch',
         operation_summary='Fase D: actualizar perfil (onboarding) parcial',
         operation_description=_USERS_ME_DESCRIPTION,

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -7,6 +7,9 @@ from rest_framework.views import APIView
 from authentication.cognito_jwt_authentication import CognitoJWTAuthentication
 from authentication.controllers.cognito_auth_controller import CognitoAuthController, map_cognito_error
 from authentication.serializers import (
+    AuthConfirmForgotPasswordSerializer,
+    AuthForgotPasswordSerializer,
+    AuthForgotPasswordValidateSerializer,
     AuthLoginSerializer,
     AuthRefreshSerializer,
     AuthRegisterSerializer,
@@ -239,6 +242,169 @@ _USERS_ME_DESCRIPTION = (
     '- **Cierre de sesión:** cuando termines, `POST /auth/logout/` con el mismo Bearer revoca la sesión en Cognito sin borrar este perfil.\n'
 )
 
+_AUTH_FORGOT_PASSWORD_DESCRIPTION = (
+    '**Recuperación de contraseña — paso 1.** Envía el código por correo vía Cognito `ForgotPassword`.\n\n'
+    '- **Orden:** `POST /auth/forgot-password/` → `POST /auth/forgot-password/validate-code/` → '
+    '`POST /auth/confirm-forgot-password/`.\n'
+    '- **Requisito:** debe existir un `Usuario` local con ese correo (paridad con Aiteva).\n'
+    '- **No** crea ni modifica `Usuario`; independiente de registro/login.\n'
+)
+
+_AUTH_FORGOT_VALIDATE_DESCRIPTION = (
+    '**Recuperación de contraseña — paso 2.** Comprueba el OTP **sin** fijar la nueva contraseña.\n\n'
+    '- Usa internamente `ConfirmForgotPassword` con el código del usuario y una **contraseña de sondeo** '
+    'controlada; si Cognito responde `InvalidPasswordException`, el OTP se considera válido para continuar.\n'
+    '- **No** se persiste el OTP en base de datos. El cambio final lo confirma Cognito en el paso 3.\n'
+)
+
+_AUTH_CONFIRM_FORGOT_DESCRIPTION = (
+    '**Recuperación de contraseña — paso 3.** `ConfirmForgotPassword` en Cognito con código y '
+    '`new_password` definitivos. Cognito es la autoridad del cambio.\n\n'
+    '- **Requisito:** mismo correo con `Usuario` local que en los pasos anteriores.\n'
+)
+
+_AUTH_FORGOT_PASSWORD_200 = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'detail': openapi.Schema(type=openapi.TYPE_STRING),
+        'email': openapi.Schema(type=openapi.TYPE_STRING, example='user@example.com'),
+    },
+)
+
+_AUTH_FORGOT_VALIDATE_200 = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'valid': openapi.Schema(
+            type=openapi.TYPE_BOOLEAN,
+            description='`true` si el código es válido ante Cognito en el patrón de sondeo.',
+        ),
+        'detail': openapi.Schema(type=openapi.TYPE_STRING),
+    },
+)
+
+_AUTH_CONFIRM_FORGOT_200 = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'detail': openapi.Schema(type=openapi.TYPE_STRING),
+        'email': openapi.Schema(type=openapi.TYPE_STRING),
+    },
+)
+
+class AuthForgotPasswordView(APIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    @swagger_auto_schema(
+        tags=['Autenticación'],
+        operation_id='auth_forgot_password',
+        operation_summary='Recuperación: enviar código al correo',
+        operation_description=_AUTH_FORGOT_PASSWORD_DESCRIPTION,
+        security=[],
+        request_body=AuthForgotPasswordSerializer,
+        responses={
+            200: openapi.Response(
+                description='Cognito ha aceptado la solicitud de recuperación.',
+                schema=_AUTH_FORGOT_PASSWORD_200,
+            ),
+            400: openapi.Response(description='Error de Cognito o parámetros.', schema=_COGNITO_ERROR),
+            404: openapi.Response(
+                description='Correo sin `Usuario` local (`Invalid credentials.`).',
+                schema=_COGNITO_ERROR,
+            ),
+            429: openapi.Response(description='Límite de velocidad de Cognito.', schema=_COGNITO_ERROR),
+        },
+    )
+    def post(self, request):
+        ser = AuthForgotPasswordSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        ctrl = CognitoAuthController()
+        try:
+            payload = ctrl.forgot_password(ser.validated_data['email'])
+        except CognitoServiceError as e:
+            code, body = map_cognito_error(e)
+            return Response(body, status=code)
+        return Response(payload, status=status.HTTP_200_OK)
+
+class AuthForgotPasswordValidateCodeView(APIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    @swagger_auto_schema(
+        tags=['Autenticación'],
+        operation_id='auth_forgot_password_validate_code',
+        operation_summary='Recuperación: validar OTP (sondeo Cognito)',
+        operation_description=_AUTH_FORGOT_VALIDATE_DESCRIPTION,
+        security=[],
+        request_body=AuthForgotPasswordValidateSerializer,
+        responses={
+            200: openapi.Response(
+                description='OTP válido en el flujo de sondeo; puedes enviar la nueva contraseña.',
+                schema=_AUTH_FORGOT_VALIDATE_200,
+            ),
+            400: openapi.Response(
+                description='Código incorrecto, expirado o error de parámetros.',
+                schema=_COGNITO_ERROR,
+            ),
+            404: openapi.Response(description='Sin `Usuario` local.', schema=_COGNITO_ERROR),
+            429: openapi.Response(description='Throttling de Cognito.', schema=_COGNITO_ERROR),
+            500: openapi.Response(
+                description='Respuesta inesperada del proveedor al validar el código.',
+                schema=_COGNITO_ERROR,
+            ),
+        },
+    )
+    def post(self, request):
+        ser = AuthForgotPasswordValidateSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        ctrl = CognitoAuthController()
+        try:
+            payload = ctrl.validate_forgot_password_code(
+                ser.validated_data['email'],
+                ser.validated_data['code'],
+            )
+        except CognitoServiceError as e:
+            code, body = map_cognito_error(e)
+            return Response(body, status=code)
+        return Response(payload, status=status.HTTP_200_OK)
+
+class AuthConfirmForgotPasswordView(APIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    @swagger_auto_schema(
+        tags=['Autenticación'],
+        operation_id='auth_confirm_forgot_password',
+        operation_summary='Recuperación: nueva contraseña definitiva',
+        operation_description=_AUTH_CONFIRM_FORGOT_DESCRIPTION,
+        security=[],
+        request_body=AuthConfirmForgotPasswordSerializer,
+        responses={
+            200: openapi.Response(
+                description='Contraseña actualizada en Cognito.',
+                schema=_AUTH_CONFIRM_FORGOT_200,
+            ),
+            400: openapi.Response(
+                description='Código inválido, contraseña débil u otro error Cognito.',
+                schema=_COGNITO_ERROR,
+            ),
+            404: openapi.Response(description='Sin `Usuario` local.', schema=_COGNITO_ERROR),
+            429: openapi.Response(description='Throttling de Cognito.', schema=_COGNITO_ERROR),
+        },
+    )
+    def post(self, request):
+        ser = AuthConfirmForgotPasswordSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        ctrl = CognitoAuthController()
+        try:
+            payload = ctrl.confirm_forgot_password(
+                ser.validated_data['email'],
+                ser.validated_data['code'],
+                ser.validated_data['new_password'],
+            )
+        except CognitoServiceError as e:
+            code, body = map_cognito_error(e)
+            return Response(body, status=code)
+        return Response(payload, status=status.HTTP_200_OK)
 
 class AuthSendView(APIView):
     authentication_classes = []

--- a/codemio_back/settings.py
+++ b/codemio_back/settings.py
@@ -166,6 +166,7 @@ CORS_ALLOW_CREDENTIALS = True
 
 SWAGGER_SETTINGS = {
     'USE_SESSION_AUTH': False,
+    'TAGS_SORTER': 'alpha',
     'SECURITY_DEFINITIONS': {
         'Bearer': {
             'type': 'apiKey',

--- a/codemio_back/urls.py
+++ b/codemio_back/urls.py
@@ -40,12 +40,11 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('auth/login/', AuthLoginView.as_view(), name='auth-login'),
+    path('auth/logout/', AuthLogoutView.as_view(), name='auth-logout'),
+    path('auth/refresh/', AuthRefreshView.as_view(), name='auth-refresh'),
     path('auth/send/', AuthSendView.as_view(), name='auth-send'),
     path('auth/validate/', AuthValidateView.as_view(), name='auth-validate'),
-    path('auth/register/', AuthRegisterView.as_view(), name='auth-register'),
-    path('auth/login/', AuthLoginView.as_view(), name='auth-login'),
-    path('auth/refresh/', AuthRefreshView.as_view(), name='auth-refresh'),
-    path('auth/logout/', AuthLogoutView.as_view(), name='auth-logout'),
     path('auth/forgot-password/', AuthForgotPasswordView.as_view(), name='auth-forgot-password'),
     path(
         'auth/forgot-password/validate-code/',
@@ -57,6 +56,7 @@ urlpatterns = [
         AuthConfirmForgotPasswordView.as_view(),
         name='auth-confirm-forgot-password',
     ),
+    path('auth/register/', AuthRegisterView.as_view(), name='auth-register'),
     path('users/me/', UsersMeView.as_view(), name='users-me'),
     re_path(
         r'^swagger(?P<format>\.json|\.yaml)$',

--- a/codemio_back/urls.py
+++ b/codemio_back/urls.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 from django.urls import path, re_path
 from authentication.views import (
+    AuthConfirmForgotPasswordView,
+    AuthForgotPasswordValidateCodeView,
+    AuthForgotPasswordView,
     AuthLoginView,
     AuthLogoutView,
     AuthRefreshView,
@@ -25,6 +28,9 @@ schema_view = get_schema_view(
             '**Renovación** `POST /auth/refresh/` (JSON con `refresh_token`; **sin** Bearer)\n'
             '**D** `GET|PATCH /users/me/` con `Authorization: Bearer <access_token>` (solo access token)\n'
             '**Cierre** `POST /auth/logout/` con ese mismo Bearer.\n'
+            '**Recuperación de contraseña** (independiente; requiere `Usuario` local): '
+            '`POST /auth/forgot-password/` → `POST /auth/forgot-password/validate-code/` '
+            '(validación OTP vía sondeo Cognito) → `POST /auth/confirm-forgot-password/`.\n'
         ),
         license=openapi.License(name='Codemio License'),
     ),
@@ -40,6 +46,17 @@ urlpatterns = [
     path('auth/login/', AuthLoginView.as_view(), name='auth-login'),
     path('auth/refresh/', AuthRefreshView.as_view(), name='auth-refresh'),
     path('auth/logout/', AuthLogoutView.as_view(), name='auth-logout'),
+    path('auth/forgot-password/', AuthForgotPasswordView.as_view(), name='auth-forgot-password'),
+    path(
+        'auth/forgot-password/validate-code/',
+        AuthForgotPasswordValidateCodeView.as_view(),
+        name='auth-forgot-password-validate-code',
+    ),
+    path(
+        'auth/confirm-forgot-password/',
+        AuthConfirmForgotPasswordView.as_view(),
+        name='auth-confirm-forgot-password',
+    ),
     path('users/me/', UsersMeView.as_view(), name='users-me'),
     re_path(
         r'^swagger(?P<format>\.json|\.yaml)$',


### PR DESCRIPTION
---
name: 🔄 Pull Request
about: Template para Pull Requests en CodeMio Backend
title: '[FEAT] Implementa flujo de recuperación de contraseña con validación OTP intermedia'
labels: ''
assignees: ''
---

## 📋 Información del Pull Request

### 🏷️ Versión y Ambiente

- **Versión:** v0.0.0
- **Ambiente afectado:** 
  - [x] Desarrollo
  - [ ] Producción
- **Rama base:** `develop`
- **Rama feature:** `feat/forgot-password-flow`

---

### 📝 Descripción

**¿Qué hace este PR?**

Implementa el flujo de recuperación de contraseña en `codemio_back` con tres endpoints separados:

- `POST /auth/forgot-password/`
- `POST /auth/forgot-password/validate-code/`
- `POST /auth/confirm-forgot-password/`

La validación intermedia del OTP se implementa replicando el patrón usado en Aiteva: un **probe controlado** sobre `ConfirmForgotPassword`, sin persistir el OTP de Cognito en base de datos.

---

**¿Por qué es necesario este cambio?**

Porque el módulo de autenticación ya contaba con:

- verificación de correo
- registro
- login
- refresh
- logout
- onboarding/perfil

pero aún faltaba un flujo formal de recuperación de contraseña alineado con Cognito y consistente con la arquitectura del proyecto.

Además, se requería evitar una implementación ingenua del reset de contraseña y replicar el comportamiento real de Aiteva.

---

**¿Qué problema resuelve?**

Resuelve la ausencia del flujo de forgot password y agrega una validación intermedia del OTP antes del cambio final de contraseña, evitando depender únicamente de un `ConfirmForgotPassword` final a ciegas.

También deja documentado y probado el patrón de probe con contraseña de sondeo para distinguir:

- OTP válido
- OTP inválido
- OTP expirado
- errores inesperados del flujo

---

### 🔄 Pasos para Reproducir / Probar

1. Ejecutar migraciones y levantar el proyecto
2. Llamar `POST /auth/forgot-password/` con un correo existente
3. Llamar `POST /auth/forgot-password/validate-code/` con el OTP recibido
4. Llamar `POST /auth/confirm-forgot-password/` con el OTP y la nueva contraseña

**Comandos para testing:**
```bash
python manage.py test
python manage.py runserver