### PR TITLE
fix(admin): exclude admin profile from user list

### DIFF
--- a/authentication/controllers/admin_users_controller.py
+++ b/authentication/controllers/admin_users_controller.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from authentication.services import get_cognito_service
+
+
+class AdminUsersController:
+
+    def __init__(self):
+        self._cognito = get_cognito_service()
+
+    @staticmethod
+    def _attr_value_optional(user: dict, name: str) -> str | None:
+        for attr in user.get('UserAttributes') or []:
+            if attr.get('Name') == name:
+                return attr.get('Value')
+        return None
+
+    def get_cognito_state(self, email: str) -> dict:
+
+        r = self._cognito.admin_get_user_optional(email)
+        if not r:
+            return {
+                'exists': False,
+                'user_status': None,
+                'enabled': None,
+                'email_verified': None,
+            }
+        email_verified_raw = self._attr_value_optional(r, 'email_verified')
+        status = r.get('UserStatus')
+        enabled = r.get('Enabled')
+        email_verified = None
+        if email_verified_raw is not None:
+            email_verified = str(email_verified_raw).strip().lower() in ('true', '1', 'yes')
+        return {
+            'exists': True,
+            'user_status': status,
+            'enabled': enabled,
+            'email_verified': email_verified,
+        }
+
+    def sync_github_profile(self, email: str, perfil_github: str | None) -> None:
+
+        value = (perfil_github or '').strip()
+        if self._cognito.admin_get_user_optional(email) is None:
+            return
+        self._cognito.admin_update_user_attributes(email, {'custom:perfil_github': value})
+
+    def delete_in_cognito(self, email: str) -> None:
+        self._cognito.admin_delete_user(email)

--- a/authentication/permissions.py
+++ b/authentication/permissions.py
@@ -1,0 +1,15 @@
+from rest_framework.permissions import BasePermission
+
+from authentication.models import RolUsuario
+
+
+class IsAdminUsuario(BasePermission):
+
+    message = 'Acceso no autorizado.'
+
+    def has_permission(self, request, view) -> bool:
+        principal = getattr(request, 'user', None)
+        usuario = getattr(principal, 'usuario', None)
+        if not usuario:
+            return False
+        return usuario.rol == RolUsuario.ADMIN

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -1,14 +1,85 @@
 from rest_framework import serializers
+from django.conf import settings
+import bleach
+import re
 from authentication.models import Usuario
+
+_OTP_RE = re.compile(r'^\d{6}$')
+_GITHUB_URL_RE = re.compile(r'^https:\/\/github\.com\/[\w.-]+\/?$')
+_GITHUB_USERNAME_RE = re.compile(r'^[\w.-]{1,39}$')
+_HAS_HTML_TAG_RE = re.compile(r'<\s*\/?\s*[a-zA-Z][^>]*>')
+_CONTROL_CHARS_RE = re.compile(r'[\x00-\x1F\x7F]')
+
+
+def _clean_text(value: str) -> str:
+    """
+    Sanitiza texto para minimizar XSS (no aplica a HTML intencional).
+    """
+    cleaned = bleach.clean(str(value), tags=[], attributes={}, protocols=[], strip=True)
+    cleaned = _CONTROL_CHARS_RE.sub('', cleaned)
+    return cleaned.strip()
+
+
+def _validate_nombre(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if value == '':
+        return None
+    if _HAS_HTML_TAG_RE.search(str(value)):
+        raise serializers.ValidationError('El nombre no puede contener etiquetas HTML.')
+    cleaned = _clean_text(value)
+    if cleaned == '':
+        return None
+    min_len = int(getattr(settings, 'PROFILE_NAME_MIN_LEN', 2))
+    max_len = int(getattr(settings, 'PROFILE_NAME_MAX_LEN', 100))
+    if len(cleaned) < min_len:
+        raise serializers.ValidationError(f'El nombre debe tener al menos {min_len} caracteres.')
+    if len(cleaned) > max_len:
+        raise serializers.ValidationError(f'El nombre no puede exceder {max_len} caracteres.')
+    return cleaned
+
+
+def _validate_edad(value: int | None) -> int | None:
+    if value is None:
+        return None
+    min_age = int(getattr(settings, 'PROFILE_AGE_MIN', 1))
+    max_age = int(getattr(settings, 'PROFILE_AGE_MAX', 120))
+    if value < min_age:
+        raise serializers.ValidationError(f'La edad debe ser mayor o igual a {min_age}.')
+    if value > max_age:
+        raise serializers.ValidationError(f'La edad no puede ser mayor a {max_age}.')
+    return value
+
+
+def _validate_github(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if value == '':
+        return None
+    cleaned = _clean_text(value)
+    if cleaned == '':
+        return None
+    if _HAS_HTML_TAG_RE.search(str(value)):
+        raise serializers.ValidationError('El perfil de GitHub no puede contener etiquetas HTML.')
+    if not re.fullmatch(r'[A-Za-z0-9._\-/:]+', cleaned):
+        raise serializers.ValidationError('El perfil de GitHub contiene caracteres no permitidos.')
+    if not (_GITHUB_URL_RE.match(cleaned) or _GITHUB_USERNAME_RE.match(cleaned)):
+        raise serializers.ValidationError(
+            'Ingresa un usuario válido de GitHub.'
+        )
+    return cleaned
 
 class AuthSendSerializer(serializers.Serializer):
     email = serializers.EmailField()
 
 class AuthValidateSerializer(serializers.Serializer):
     email = serializers.EmailField()
-    otp = serializers.CharField(
-        max_length=32,
-        help_text='Código de verificación recibido por correo (p. ej. 123456).',
+    otp = serializers.RegexField(
+        regex=_OTP_RE,
+        max_length=6,
+        min_length=6,
+        help_text='Código OTP de 6 dígitos (solo números).',
+        error_messages={'invalid': 'OTP inválido. Debe ser un código numérico de 6 dígitos.'},
     )
 
 class AuthRegisterSerializer(serializers.Serializer):
@@ -25,15 +96,23 @@ class AuthForgotPasswordSerializer(serializers.Serializer):
 
 class AuthForgotPasswordValidateSerializer(serializers.Serializer):
     email = serializers.EmailField()
-    code = serializers.CharField(
-        max_length=32,
-        help_text='Código recibido por correo tras POST /auth/forgot-password/.',
+    code = serializers.RegexField(
+        regex=_OTP_RE,
+        max_length=6,
+        min_length=6,
+        help_text='Código OTP de 6 dígitos (solo números).',
+        error_messages={'invalid': 'Código inválido. Debe ser numérico de 6 dígitos.'},
     )
 
 
 class AuthConfirmForgotPasswordSerializer(serializers.Serializer):
     email = serializers.EmailField()
-    code = serializers.CharField(max_length=32)
+    code = serializers.RegexField(
+        regex=_OTP_RE,
+        max_length=6,
+        min_length=6,
+        error_messages={'invalid': 'Código inválido. Debe ser numérico de 6 dígitos.'},
+    )
     new_password = serializers.CharField(write_only=True, min_length=8, max_length=128)
 
 
@@ -90,14 +169,13 @@ class UsuarioProfileSerializer(serializers.ModelSerializer):
         }
 
     def validate_edad(self, value):
-        if value is not None and value < 0:
-            raise serializers.ValidationError('La edad no puede ser negativa.')
-        return value
+        return _validate_edad(value)
+
+    def validate_nombre(self, value):
+        return _validate_nombre(value)
 
     def validate_perfil_github(self, value):
-        if value == '':
-            return None
-        return value
+        return _validate_github(value)
 
 
 class AdminUsuarioReadSerializer(serializers.ModelSerializer):
@@ -127,11 +205,10 @@ class AdminUsuarioUpdateSerializer(serializers.ModelSerializer):
         }
 
     def validate_edad(self, value):
-        if value is not None and value < 0:
-            raise serializers.ValidationError('La edad no puede ser negativa.')
-        return value
+        return _validate_edad(value)
+
+    def validate_nombre(self, value):
+        return _validate_nombre(value)
 
     def validate_perfil_github(self, value):
-        if value == '':
-            return None
-        return value
+        return _validate_github(value)

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -98,3 +98,40 @@ class UsuarioProfileSerializer(serializers.ModelSerializer):
         if value == '':
             return None
         return value
+
+
+class AdminUsuarioReadSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Usuario
+        fields = (
+            'id',
+            'correo',
+            'rol',
+            'nombre',
+            'edad',
+            'perfil_github',
+            'fecha_registro',
+            'sub_cognito',
+        )
+        read_only_fields = fields
+
+
+class AdminUsuarioUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Usuario
+        fields = ('nombre', 'edad', 'perfil_github')
+        extra_kwargs = {
+            'nombre': {'required': False, 'allow_null': True, 'allow_blank': True},
+            'edad': {'required': False, 'allow_null': True},
+            'perfil_github': {'required': False, 'allow_null': True, 'allow_blank': True},
+        }
+
+    def validate_edad(self, value):
+        if value is not None and value < 0:
+            raise serializers.ValidationError('La edad no puede ser negativa.')
+        return value
+
+    def validate_perfil_github(self, value):
+        if value == '':
+            return None
+        return value

--- a/authentication/services/cognito_service.py
+++ b/authentication/services/cognito_service.py
@@ -107,6 +107,37 @@ class CognitoService:
             self._log_client_error('AdminGetUser', email, e)
             raise self._map_client_error(e) from e
 
+    def admin_get_user_optional(self, email: str) -> dict[str, Any] | None:
+
+        return self._admin_get_user_optional(email)
+
+    def admin_update_user_attributes(self, email: str, attributes: dict[str, str]) -> dict[str, Any]:
+
+        try:
+            response = self.client.admin_update_user_attributes(
+                UserPoolId=self.user_pool_id,
+                Username=email,
+                UserAttributes=[{'Name': k, 'Value': v} for k, v in attributes.items()],
+            )
+            self._log_success('AdminUpdateUserAttributes', email, response)
+            return response
+        except ClientError as e:
+            self._log_client_error('AdminUpdateUserAttributes', email, e)
+            raise self._map_client_error(e) from e
+
+    def admin_delete_user(self, email: str) -> dict[str, Any]:
+
+        try:
+            response = self.client.admin_delete_user(UserPoolId=self.user_pool_id, Username=email)
+            self._log_success('AdminDeleteUser', email, response)
+            return response
+        except ClientError as e:
+            # Si no existe, tratamos como idempotente para el flujo de borrado local.
+            if e.response.get('Error', {}).get('Code') == 'UserNotFoundException':
+                return {'deleted': False, 'reason': 'UserNotFoundException'}
+            self._log_client_error('AdminDeleteUser', email, e)
+            raise self._map_client_error(e) from e
+
     def _user_status_optional(self, email: str) -> str | None:
         r = self._admin_get_user_optional(email)
         return r.get('UserStatus') if r else None

--- a/authentication/tests/test_admin_users_api.py
+++ b/authentication/tests/test_admin_users_api.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from authentication.models import RolUsuario, Usuario
+from authentication.principal import CognitoPrincipal
+
+
+class AdminUsersApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = Usuario.objects.create(
+            correo='admin@example.com',
+            sub_cognito='sub-admin',
+            rol=RolUsuario.ADMIN,
+        )
+        self.user = Usuario.objects.create(
+            correo='user@example.com',
+            sub_cognito='sub-user',
+            rol=RolUsuario.USER,
+            nombre='User',
+            edad=20,
+            perfil_github='old',
+        )
+
+    def test_non_admin_forbidden(self):
+        self.client.force_authenticate(user=CognitoPrincipal(self.user))
+        r = self.client.get('/users/')
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch('authentication.controllers.admin_users_controller.get_cognito_service')
+    def test_admin_list_users(self, get_cognito_service_mock):
+        cognito = get_cognito_service_mock.return_value
+        cognito.admin_get_user_optional.return_value = None
+
+        self.client.force_authenticate(user=CognitoPrincipal(self.admin))
+        r = self.client.get('/users/')
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(r.data, list)
+        ids = [row.get('id') for row in r.data]
+        self.assertNotIn(self.admin.id, ids)
+        self.assertIn(self.user.id, ids)
+        self.assertIn('cognito', r.data[0])
+
+    @patch('authentication.controllers.admin_users_controller.get_cognito_service')
+    def test_admin_get_user(self, get_cognito_service_mock):
+        cognito = get_cognito_service_mock.return_value
+        cognito.admin_get_user_optional.return_value = {
+            'UserStatus': 'CONFIRMED',
+            'Enabled': True,
+            'UserAttributes': [{'Name': 'email_verified', 'Value': 'true'}],
+        }
+
+        self.client.force_authenticate(user=CognitoPrincipal(self.admin))
+        r = self.client.get(f'/users/{self.user.id}/')
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data['id'], self.user.id)
+        self.assertEqual(r.data['correo'], 'user@example.com')
+        self.assertEqual(r.data['rol'], RolUsuario.USER)
+        self.assertEqual(r.data['cognito']['email_verified'], True)
+
+    @patch('authentication.controllers.admin_users_controller.get_cognito_service')
+    def test_admin_patch_only_allowed_fields(self, get_cognito_service_mock):
+        cognito = get_cognito_service_mock.return_value
+        cognito.admin_get_user_optional.return_value = {'UserAttributes': []}
+        cognito.admin_update_user_attributes.return_value = {}
+
+        self.client.force_authenticate(user=CognitoPrincipal(self.admin))
+        r = self.client.patch(
+            f'/users/{self.user.id}/',
+            {
+                'nombre': 'Nuevo Nombre',
+                'edad': 30,
+                'perfil_github': 'new',
+            },
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.nombre, 'Nuevo Nombre')
+        self.assertEqual(self.user.edad, 30)
+        self.assertEqual(self.user.perfil_github, 'new')
+        cognito.admin_update_user_attributes.assert_called()
+
+        # No debe permitir cambiar correo/rol
+        r2 = self.client.patch(
+            f'/users/{self.user.id}/',
+            {'correo': 'hacked@example.com', 'rol': RolUsuario.ADMIN},
+            format='json',
+        )
+        self.assertEqual(r2.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch('authentication.controllers.admin_users_controller.get_cognito_service')
+    def test_admin_delete_user(self, get_cognito_service_mock):
+        cognito = get_cognito_service_mock.return_value
+        cognito.admin_delete_user.return_value = {}
+
+        self.client.force_authenticate(user=CognitoPrincipal(self.admin))
+        r = self.client.delete(f'/users/{self.user.id}/')
+        self.assertEqual(r.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Usuario.objects.filter(id=self.user.id).exists())
+        cognito.admin_delete_user.assert_called_with('user@example.com')

--- a/authentication/tests/test_forgot_password_flow.py
+++ b/authentication/tests/test_forgot_password_flow.py
@@ -167,7 +167,7 @@ class ForgotPasswordApiTests(TestCase):
         )
         r = self.client.post(
             '/auth/confirm-forgot-password/',
-            {'email': self.email, 'code': 'x', 'new_password': 'Newpass1!x'},
+            {'email': self.email, 'code': '123456', 'new_password': 'Newpass1!x'},
             format='json',
         )
         self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
@@ -184,7 +184,7 @@ class ForgotPasswordApiTests(TestCase):
         )
         r = self.client.post(
             '/auth/forgot-password/validate-code/',
-            {'email': self.email, 'code': '1'},
+            {'email': self.email, 'code': '123456'},
             format='json',
         )
         self.assertEqual(r.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -5,13 +5,18 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from authentication.cognito_jwt_authentication import CognitoJWTAuthentication
+from authentication.controllers.admin_users_controller import AdminUsersController
 from authentication.controllers.cognito_auth_controller import CognitoAuthController, map_cognito_error
+from authentication.models import Usuario
+from authentication.permissions import IsAdminUsuario
 from authentication.services.payload_crypto import (
     PayloadCryptoError,
     decrypt_profile_payload,
     get_public_key_payload,
 )
 from authentication.serializers import (
+    AdminUsuarioReadSerializer,
+    AdminUsuarioUpdateSerializer,
     AuthConfirmForgotPasswordSerializer,
     AuthForgotPasswordSerializer,
     AuthForgotPasswordValidateSerializer,
@@ -729,3 +734,109 @@ class ProfilePayloadPublicKeyView(APIView):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         return Response(payload, status=status.HTTP_200_OK)
+
+
+class AdminUsersListView(APIView):
+    authentication_classes = [CognitoJWTAuthentication]
+    permission_classes = [IsAuthenticated, IsAdminUsuario]
+
+    @swagger_auto_schema(
+        tags=['06 Administración de usuarios'],
+        operation_id='admin_users_list',
+        operation_summary='Admin: listar usuarios',
+        security=[{'Bearer': []}],
+        responses={200: openapi.Response(description='Lista de usuarios (local + estado Cognito).')},
+    )
+    def get(self, request):
+        ctrl = AdminUsersController()
+        me = request.user.usuario
+        usuarios = (
+            Usuario.objects.exclude(id=me.id)
+            .exclude(sub_cognito=me.sub_cognito)
+            .order_by('-fecha_registro')
+        )
+        out = []
+        for u in usuarios:
+            row = AdminUsuarioReadSerializer(u).data
+            row['cognito'] = ctrl.get_cognito_state(u.correo)
+            out.append(row)
+        return Response(out, status=status.HTTP_200_OK)
+
+
+class AdminUsersDetailView(APIView):
+    authentication_classes = [CognitoJWTAuthentication]
+    permission_classes = [IsAuthenticated, IsAdminUsuario]
+
+    @swagger_auto_schema(
+        tags=['06 Administración de usuarios'],
+        operation_id='admin_users_get',
+        operation_summary='Admin: ver usuario',
+        security=[{'Bearer': []}],
+        responses={200: openapi.Response(description='Usuario (local + estado Cognito).')},
+    )
+    def get(self, request, user_id: int):
+        try:
+            usuario = Usuario.objects.get(id=user_id)
+        except Usuario.DoesNotExist:
+            return Response({'detail': 'Usuario no encontrado.'}, status=status.HTTP_404_NOT_FOUND)
+        ctrl = AdminUsersController()
+        payload = AdminUsuarioReadSerializer(usuario).data
+        payload['cognito'] = ctrl.get_cognito_state(usuario.correo)
+        return Response(payload, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(
+        tags=['06 Administración de usuarios'],
+        operation_id='admin_users_patch',
+        operation_summary='Admin: actualizar usuario (solo nombre/edad/perfil_github)',
+        security=[{'Bearer': []}],
+        request_body=AdminUsuarioUpdateSerializer,
+        responses={200: openapi.Response(description='Usuario actualizado (local + estado Cognito).')},
+    )
+    def patch(self, request, user_id: int):
+        try:
+            usuario = Usuario.objects.get(id=user_id)
+        except Usuario.DoesNotExist:
+            return Response({'detail': 'Usuario no encontrado.'}, status=status.HTTP_404_NOT_FOUND)
+
+        allowed = {'nombre', 'edad', 'perfil_github'}
+        unknown = set(request.data.keys()) - allowed
+        if unknown:
+            return Response(
+                {
+                    'code': 'AdminUserPatchInvalidFields',
+                    'detail': 'Solo se permiten los campos: nombre, edad, perfil_github.',
+                    'invalid_fields': sorted(list(unknown)),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        ser = AdminUsuarioUpdateSerializer(usuario, data=request.data, partial=True)
+        ser.is_valid(raise_exception=True)
+        ser.save()
+        usuario.refresh_from_db()
+
+        ctrl = AdminUsersController()
+        if 'perfil_github' in ser.validated_data:
+            ctrl.sync_github_profile(usuario.correo, usuario.perfil_github)
+
+        payload = AdminUsuarioReadSerializer(usuario).data
+        payload['cognito'] = ctrl.get_cognito_state(usuario.correo)
+        return Response(payload, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(
+        tags=['06 Administración de usuarios'],
+        operation_id='admin_users_delete',
+        operation_summary='Admin: eliminar usuario (local + Cognito)',
+        security=[{'Bearer': []}],
+        responses={204: openapi.Response(description='Usuario eliminado.')},
+    )
+    def delete(self, request, user_id: int):
+        try:
+            usuario = Usuario.objects.get(id=user_id)
+        except Usuario.DoesNotExist:
+            return Response({'detail': 'Usuario no encontrado.'}, status=status.HTTP_404_NOT_FOUND)
+
+        ctrl = AdminUsersController()
+        ctrl.delete_in_cognito(usuario.correo)
+        usuario.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,6 +1,7 @@
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -301,6 +302,8 @@ _AUTH_CONFIRM_FORGOT_200 = openapi.Schema(
 class AuthForgotPasswordView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'auth_forgot_password'
 
     @swagger_auto_schema(
         tags=['03 Recuperación de contraseña'],
@@ -336,6 +339,8 @@ class AuthForgotPasswordView(APIView):
 class AuthForgotPasswordValidateCodeView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'auth_forgot_validate'
 
     @swagger_auto_schema(
         tags=['03 Recuperación de contraseña'],
@@ -378,6 +383,8 @@ class AuthForgotPasswordValidateCodeView(APIView):
 class AuthConfirmForgotPasswordView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'auth_confirm_forgot'
 
     @swagger_auto_schema(
         tags=['03 Recuperación de contraseña'],
@@ -417,6 +424,8 @@ class AuthConfirmForgotPasswordView(APIView):
 class AuthSendView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'auth_send'
 
     @swagger_auto_schema(
         tags=['02 Verificación de correo'],
@@ -455,6 +464,8 @@ class AuthSendView(APIView):
 class AuthValidateView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'auth_validate'
 
     @swagger_auto_schema(
         tags=['02 Verificación de correo'],
@@ -497,6 +508,8 @@ class AuthValidateView(APIView):
 class AuthRegisterView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'auth_register'
 
     @swagger_auto_schema(
         tags=['04 Registro y login'],
@@ -541,6 +554,8 @@ class AuthRegisterView(APIView):
 class AuthLoginView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'auth_login'
 
     @swagger_auto_schema(
         tags=['01 Sesión', '04 Registro y login'],

--- a/codemio_back/settings.py
+++ b/codemio_back/settings.py
@@ -193,7 +193,26 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10,
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.ScopedRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        # Sensibles (anti brute-force). Ajustar según entorno.
+        'auth_send': '10/min',
+        'auth_validate': '10/min',
+        'auth_login': '10/min',
+        'auth_register': '10/min',
+        'auth_forgot_password': '5/min',
+        'auth_forgot_validate': '10/min',
+        'auth_confirm_forgot': '5/min',
+    },
 }
+
+# Validaciones de perfil (usuarios) — fijas (no por entorno)
+PROFILE_NAME_MIN_LEN = 2
+PROFILE_NAME_MAX_LEN = 100
+PROFILE_AGE_MIN = 1
+PROFILE_AGE_MAX = 120
 
 AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', default='')
 AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default='')

--- a/codemio_back/urls.py
+++ b/codemio_back/urls.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from django.urls import include, path, re_path
 from authentication.views import (
+    AdminUsersDetailView,
+    AdminUsersListView,
     AuthConfirmForgotPasswordView,
     AuthForgotPasswordValidateCodeView,
     AuthForgotPasswordView,
@@ -61,6 +63,8 @@ urlpatterns = [
     path('auth/register/', AuthRegisterView.as_view(), name='auth-register'),
     path('auth/payload-public-key/', ProfilePayloadPublicKeyView.as_view(), name='auth-payload-public-key'),
     path('users/me/', UsersMeView.as_view(), name='users-me'),
+    path('users/', AdminUsersListView.as_view(), name='admin-users-list'),
+    path('users/<int:user_id>/', AdminUsersDetailView.as_view(), name='admin-users-detail'),
     re_path(
         r'^swagger(?P<format>\.json|\.yaml)$',
         schema_view.without_ui(cache_timeout=0),

--- a/projects/views.py
+++ b/projects/views.py
@@ -14,6 +14,8 @@ class ProjectListCreateView(ListCreateAPIView):
     serializer_class = ProjectSerializer
 
     def get_queryset(self):
+        if getattr(self, 'swagger_fake_view', False):
+            return Project.objects.none()
         return Project.objects.filter(user=self.request.user.usuario, state=ProjectState.ACTIVE)
 
     def perform_create(self, serializer):
@@ -26,6 +28,8 @@ class ProjectDetailView(RetrieveUpdateDestroyAPIView):
     serializer_class = ProjectSerializer
 
     def get_queryset(self):
+        if getattr(self, 'swagger_fake_view', False):
+            return Project.objects.none()
         return Project.objects.filter(user=self.request.user.usuario, state=ProjectState.ACTIVE)
 
     def destroy(self, request, *args, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ boto3==1.35.99
 # JWT (tokens Cognito para endpoints autenticados)
 PyJWT==2.10.1
 cryptography==44.0.2
+bleach==6.2.0
 
 # API documentation
 drf-yasg==1.21.8


### PR DESCRIPTION
## 📋 Información del Pull Request

### 🏷️ Versión y Ambiente

- **Versión:** v1.0.0
- **Ambiente afectado:**
  - [x] Desarrollo
  - [ ] Producción
- **Rama base:** `develop`
- **Rama feature:** `feature/BE-ADMIN-01`

---

### 📝 Descripción

**¿Qué hace este PR?**

Implementa en el **backend** los endpoints de **administración de usuarios** para que un **ADMIN** pueda:

- **Listar** usuarios (`GET /users/`) excluyendo su propio perfil.
- **Ver detalle** de un usuario (`GET /users/<id>/`).
- **Editar** solo `nombre`, `edad`, `perfil_github` (`PATCH /users/<id>/`).
- **Eliminar** un usuario en **BD local** y en **AWS Cognito** (`DELETE /users/<id>/`).

Las respuestas incluyen un bloque `cognito` con el estado remoto (`exists`, `user_status`, `enabled`, `email_verified`).

**¿Por qué es necesario este cambio?**

- Permite gestión de usuarios por ADMIN sin permitir cambios sensibles como **correo** o **rol**.
- Asegura sincronización con **Cognito** al actualizar `perfil_github` (atributo `custom:perfil_github`) y al eliminar usuarios.
- Refuerza validaciones de campos editables para evitar datos inválidos y minimizar XSS.

**¿Qué problema resuelve?**

Resuelve la ausencia de endpoints backend para **gestión segura de usuarios** por parte del administrador y la falta de integración consistente con **Cognito** en actualización/borrado.

---

### 🔄 Pasos para Reproducir / Probar

1. Inicia sesión como **ADMIN** y obtén `tokens.access_token`.
2. Llama `GET /users/` y valida:
   - Responde `200` con lista
   - No aparece el usuario admin autenticado
   - Cada item trae `cognito`
3. Llama `GET /users/<user_id>/` y valida el payload + `cognito`.
4. Llama `PATCH /users/<user_id>/` con `nombre`, `edad`, `perfil_github` y valida que persiste en BD.
5. Intenta `PATCH /users/<user_id>/` con `correo` o `rol` y valida que responde `400`.
6. Llama `DELETE /users/<user_id>/` y valida `204`, que se elimina en BD y se invoca borrado en Cognito.

**Comandos para testing:**
```bash
python manage.py test authentication.tests
python manage.py runserver
```

---

### 🎫 Ticket Relacionado

- **Issue:** N/A
- **Jira/Trello:** N/A
- **Documentación:** N/A

---

### 📸 Capturas de Pantalla

**Antes:**
<!-- Imagen del estado anterior -->

**Después:**
<!-- Imagen del nuevo estado -->

---

### ℹ️ Información Adicional

#### 🔧 Cambios Técnicos

- **Archivos modificados:**
  - `codemio_back/urls.py` (rutas admin users)
  - `authentication/views.py` (AdminUsersListView/AdminUsersDetailView)
  - `authentication/serializers.py` (AdminUsuarioReadSerializer/AdminUsuarioUpdateSerializer + validaciones)
  - `authentication/controllers/admin_users_controller.py` (estado Cognito, sync github, delete Cognito)
  - `authentication/services/cognito_service.py` (operaciones admin: get/update/delete)
  - `authentication/permissions.py` (permiso `IsAdminUsuario`)
  - `authentication/tests/test_admin_users_api.py` (tests endpoints admin users)

- **Nuevas dependencias:**
  - [ ] No se agregaron nuevas dependencias
  - [x] Sí, se agregaron: `boto3`

- **Migraciones de BD:**
  - [x] No requiere migraciones
  - [ ] Sí, requiere ejecutar: `python manage.py migrate`

- **Variables de entorno:**
  - [ ] No requiere nuevas variables
  - [x] Sí, requiere agregar al `.env`:
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
    - `AWS_COGNITO_REGION`
    - `AWS_COGNITO_USER_POOL_ID`
    - `AWS_COGNITO_CLIENT_ID`
    - `AWS_COGNITO_CLIENT_SECRET`
    - `AWS_COGNITO_ISSUER`
    - `AWS_COGNITO_DOMAIN`

#### 🧪 Testing

- [x] Tests unitarios agregados/actualizados
- [x] Tests de integración agregados/actualizados
- [ ] Todos los tests existentes pasan
- [ ] Coverage se mantiene o mejora

#### 📚 Documentación

- [ ] README.md actualizado (si aplica)
- [ ] COMMANDS.md actualizado (si aplica)
- [ ] Docstrings agregados/actualizados
- [ ] CONFIGURATION_SUMMARY.md actualizado (si aplica)
- [ ] PROJECT_MAP.md actualizado (si aplica)

#### 🎯 Checklist

- [x] El código sigue las convenciones de [Conventional Commits](https://www.conventionalcommits.org/)
- [x] He realizado self-review de mi código
- [ ] He comentado el código en áreas complejas
- [x] Mis cambios no generan nuevos warnings
- [ ] El linting pasa sin errores (`flake8`)
- [ ] He actualizado la documentación relevante
- [x] Mis cambios no rompen funcionalidad existente

#### 🔒 Seguridad

- [x] No se exponen credenciales o información sensible
- [x] Se siguen las mejores prácticas de seguridad
- [x] Las variables sensibles están en `.env`
- [x] No se hace commit de archivos `.env`

#### ⚡ Performance

- [x] No se identifican problemas de performance
- [x] Se consideraron optimizaciones necesarias
- [x] Las queries a BD están optimizadas

---

### 👥 Reviewers

@MiguelSP040

---

### 🚀 Deployment

- [x] Listo para merge a develop
- [ ] Listo para merge a main
- [ ] Requiere deployment manual
- [x] Requiere configuración adicional en producción

**Notas de deployment:**
- Configurar variables `AWS_COGNITO_*` y credenciales AWS en el entorno.
- Verificar permisos IAM para `cognito-idp` (admin_get_user, admin_update_user_attributes, admin_delete_user).

---

### 📝 Notas Adicionales

- `PATCH /users/<id>/` rechaza cualquier campo fuera de `nombre`, `edad`, `perfil_github` con error `AdminUserPatchInvalidFields`.
- Si cambia `perfil_github`, se sincroniza en Cognito como `custom:perfil_github`.

---

### 🏁 Post-Merge Checklist

- [ ] Verificar deployment exitoso
- [ ] Monitorear logs por errores
- [ ] Verificar métricas de performance
- [ ] Actualizar stakeholders
- [x] Cerrar issue relacionado

---

**Tipo de cambio:**
- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 💥 Breaking change
- [ ] 📝 Documentación
- [ ] 🎨 Mejora de UI/UX
- [ ] ⚡ Mejora de performance
- [ ] ♻️ Refactorización
- [ ] 🔧 Configuración
- [ ] 🔒 Seguridad